### PR TITLE
feat: docker compose infra helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,16 @@ cp .env.example .env
 docker network create hypertube-network
 ```
 
-### 3. Start the databases
+### 3. Start the infra
 
 ```bash
 docker compose up
+```
+
+### 4. [OPTIONAL] Start infra helpers
+
+```bash
+docker compose -f docker-compose-helpers.yml up
 ```
 
 ## 📂 Launch Modes

--- a/docker-compose-helpers.yml
+++ b/docker-compose-helpers.yml
@@ -1,0 +1,25 @@
+services:
+  adminer:
+    container_name: hypertube_adminer
+    image: adminer
+    ports:
+      - 8080:8080
+    networks:
+      - hypertube-network
+
+  redisinsight:
+    container_name: hypertube_redisinsight
+    image: redis/redisinsight:latest
+    ports:
+      - 5540:5540
+    volumes:
+      - redisinsight:/data
+    networks:
+      - hypertube-network
+
+networks:
+  hypertube-network:
+    external: true
+
+volumes:
+  redisinsight:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,10 +3,6 @@ services:
     ports:
       - "${POSTGRES_PORT}:${POSTGRES_PORT}"
 
-  adminer:
-    ports:
-      - "8080:8080"
-
   transmission:
     ports:
       - "${TRANSMISSION_RCP_PORT}:${TRANSMISSION_RCP_PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,17 +15,6 @@ services:
       timeout: 5s
       retries: 5
 
-  adminer:
-    container_name: hypertube_adminer
-    image: adminer
-    ports:
-      - 8080
-    networks:
-      - hypertube-network
-    depends_on:
-      db:
-        condition: service_healthy
-
   transmission:
     container_name: transmission
     image: linuxserver/transmission


### PR DESCRIPTION
redisinsight c'est comme adminer mais pour redis ca permet de regarder ce qu'il se passe dedans pour debug voir les perfs etc.
Et ducoup je sort adminer de l'infra pck en prod ca sert a rien de le lancer.