### PR TITLE
refacto: email style

### DIFF
--- a/apps/server/src/emails/default-email.html
+++ b/apps/server/src/emails/default-email.html
@@ -9,7 +9,7 @@
     style="
       margin: 0;
       padding: 0;
-      background-color: #f4f4f4;
+      background-color: #262626;
       font-family: Arial, sans-serif;
     "
   >
@@ -21,7 +21,7 @@
             style="
               width: 600px;
               margin: 0 auto;
-              background: #ffffff;
+              background: #30302e;
               border-radius: 8px;
               box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
             "
@@ -34,7 +34,7 @@
                       <img
                         src="https://via.placeholder.com/150x50"
                         alt="Hypertube Logo"
-                        style="max-width: 150px; height: auto"
+                        style="max-width: 150px; height: auto; color: #f7f0d7"
                       />
                     </td>
                   </tr>
@@ -42,7 +42,7 @@
                     <td>
                       <h1
                         style="
-                          color: #333333;
+                          color: #f7f0d7;
                           font-size: 24px;
                           margin: 0 0 20px;
                           text-align: center;
@@ -52,7 +52,7 @@
                       </h1>
                       <p
                         style="
-                          color: #666666;
+                          color: #f7f0d7;
                           font-size: 16px;
                           line-height: 24px;
                           margin: 0 0 30px;
@@ -70,10 +70,10 @@
                         style="
                           display: inline-block;
                           padding: 12px 30px;
-                          background-color: #ff69b4;
-                          color: #ffffff;
+                          background-color: #efb100;
+                          color: #000000;
                           text-decoration: none;
-                          border-radius: 25px;
+                          border-radius: 6px;
                           font-weight: bold;
                           text-transform: uppercase;
                           font-size: 14px;


### PR DESCRIPTION
Je suis resté sur le template de base pour avoir un email générique, sauf si plus tard, vous voulez des emails plus situationnels, pour l'instant, j'ai simplement utilisé les couleurs de notre site en dark mode (light mode beurk) et le bouton a un peu plus de style du default button de shadcn

Avant / Après : 

<img width="820" height="526" alt="{BF63F94E-8106-4FB2-91C7-D88D79B5F3A2}" src="https://github.com/user-attachments/assets/fae658ea-c143-49b6-aa57-7ad68083160e" />

<img width="708" height="505" alt="{AEB0CCC4-A3D3-401D-AE63-0344710F4627}" src="https://github.com/user-attachments/assets/bd4e8f57-cb71-469e-b165-57b836648534" />
